### PR TITLE
Delete "Nature runbook" mentioned in css.md

### DIFF
--- a/languages/css.md
+++ b/languages/css.md
@@ -2,7 +2,7 @@
 # CSS Style Guide -- WIP
 
 
-This document aspires to outline the way we write CSS/SASS, and is based at the moment on the existing [Nature runbook]. This is just a first pass, and is likely to be incomplete (and wrong) in places.  It's a living styleguide – it will grow and adapt as our practices do.
+This document aspires to outline the way we write CSS/SASS. This is just a first pass, and is likely to be incomplete (and wrong) in places.  It's a living styleguide – it will grow and adapt as our practices do.
 
 Projects should use [StyleLint] to enforce these rules. You can find _an example_ config file in the [config directory](config).
 
@@ -723,7 +723,6 @@ But in the following example we would not use it:
 }
 ```
 
-[Nature runbook]: https://github.com/nature/playbook
 [bem]: https://github.com/springernature/frontend/languages/bem-css.md
 [a hybrid of OOCSS and Atomic CSS]: https://github.com/springernature/frontend/languages/mosaic-css.md
 [stylelint]: https://github.com/stylelint/stylelint


### PR DESCRIPTION
The URL of "Nature runbook" https://github.com/nature/playbook is 404 now.